### PR TITLE
Make Rust 1.0-compatable

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,12 @@
 //! Yet Another OAuth 1.0 Client Library for Rust
 
-#![feature(std_misc)]
-#![unstable]
-
 extern crate crypto;
 extern crate rand;
-extern crate "rustc-serialize" as serialize;
+extern crate rustc_serialize as serialize;
 extern crate time;
 extern crate url;
 
-use std::ascii::{AsciiExt, OwnedAsciiExt};
+use std::ascii::AsciiExt;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::{self, Write};
@@ -21,14 +18,11 @@ use serialize::base64::{self, ToBase64};
 use url::{percent_encoding, Url};
 
 /// Available `oauth_signature_method` types.
-#[derive(Copy, Debug, PartialEq, Eq)]
-#[stable]
+#[derive(Copy, Debug, PartialEq, Eq, Clone)]
 pub enum SignatureMethod {
     /// HMAC-SHA1
-    #[stable]
     HmacSha1,
     /// PLAINTEXT
-    #[stable]
     Plaintext
 }
 
@@ -87,20 +81,20 @@ fn percent_encode(input: &str) -> String {
 }
 
 fn base_string_url(url: Url) -> String {
-    let scheme = url.scheme.into_ascii_lowercase();
-    assert!(match &scheme[]
+    let scheme = url.scheme.to_ascii_lowercase();
+    assert!(match &scheme[..]
         { "http" => true, "https" => true, _ => false });
     let mut result = format!("{}://", scheme);
     match url.scheme_data {
         url::SchemeData::Relative(data) => {
-            result.push_str(&data.host.to_string().into_ascii_lowercase()[]);
+            result.push_str(&data.host.to_string().to_ascii_lowercase()[..]);
             match data.port {
                 Some(p) => if p != data.default_port.unwrap() {
                     write!(&mut result, ":{}", p).ok();
                  },
                  None => ()
             }
-            result.push_str(&data.serialize_path()[]);
+            result.push_str(&data.serialize_path()[..]);
         },
         url::SchemeData::NonRelative(_) => panic!("scheme_data is NonRelative")
     }
@@ -110,7 +104,7 @@ fn base_string_url(url: Url) -> String {
 fn normalize_parameters<P>(params: P) -> String
         where P: Iterator<Item = (String, String)> {
     let mut mutparams: Vec<_> = params
-        .map(|x| (percent_encode(&x.0[]), percent_encode(&x.1[])))
+        .map(|x| (percent_encode(&x.0[..]), percent_encode(&x.1[..])))
         .collect();
     mutparams.sort_by(|a, b| {
         match a.0.cmp(&b.0) {
@@ -127,14 +121,12 @@ fn normalize_parameters<P>(params: P) -> String
 }
 
 /// Generate a string for `oauth_timestamp`.
-#[stable]
 #[inline]
 pub fn timestamp() -> String {
     time::now_utc().to_timespec().sec.to_string()
 }
 
 /// Generate a string for `oauth_nonce`.
-#[stable]
 #[inline]
 pub fn nonce() -> String {
     rand::thread_rng()
@@ -178,8 +170,8 @@ fn signature_base_string<P>(method: &str, url: Url,
     format!(
         "{}&{}&{}",
         method.to_ascii_uppercase(),
-        percent_encode(&base_string_url(url)[]),
-        percent_encode(&normalize_parameters(mutparams.into_iter())[])
+        percent_encode(&base_string_url(url)[..]),
+        percent_encode(&normalize_parameters(mutparams.into_iter())[..])
     )
 }
 
@@ -207,7 +199,6 @@ fn signature(base_string: String, signature_method: SignatureMethod,
 
 /// Generate OAuth parameters set.
 /// The return value contains elements whose key is `"oauth_foo"`.
-#[unstable]
 pub fn protocol_parameters<P>(method: &str, url: Url, realm: Option<&str>,
         consumer_key: &str, consumer_secret: &str, token: Option<&str>,
         token_secret: Option<&str>, signature_method: SignatureMethod,
@@ -229,7 +220,6 @@ pub fn protocol_parameters<P>(method: &str, url: Url, realm: Option<&str>,
 
 /// Generate `Authorization` header for OAuth.
 /// The return value starts with `"OAuth "`.
-#[unstable]
 pub fn authorization_header<P>(method: &str, url: Url, realm: Option<&str>,
         consumer_key: &str, consumer_secret: &str, token: Option<&str>,
         token_secret: Option<&str>, signature_method: SignatureMethod,
@@ -241,7 +231,7 @@ pub fn authorization_header<P>(method: &str, url: Url, realm: Option<&str>,
         token, token_secret, signature_method, timestamp, nonce, callback, verifier, params);
     format!("OAuth {}", p.iter()
         .map(|(key, val)| format!("{}=\"{}\"",
-            percent_encode(*key), percent_encode(&val[])))
+            percent_encode(*key), percent_encode(&val[..])))
         .collect::<Vec<String>>()
         .connect(",")
     )


### PR DESCRIPTION
- Eliminates stability notations because "stability attributes may not be
  used outside of the standard library"
- Uses `to_ascii_lowercase` rather than the deprecated
  `into_ascii_lowercase`
- Derives `Clone` for `SignatureMethod`
- Updates some slice syntax issues
