### PR TITLE
expose url crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,11 @@ Yet Another OAuth 1.0 Client Library for Rust
 # How to Use
 ```rust
 extern crate oauthcli;
-extern crate url;
 
 let header =
   oauthcli::authorization_header(
     "POST",
-    url::Url::parse("https://example").unwrap(),
+    oauthcli::url::Url::parse("https://example").unwrap(),
     None, // Realm
     "Consumer Key",
     "Consumer Secret",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ extern crate crypto;
 extern crate rand;
 extern crate rustc_serialize as serialize;
 extern crate time;
-extern crate url;
+pub extern crate url;
 
 use std::ascii::AsciiExt;
 use std::cmp::Ordering;


### PR DESCRIPTION
Expose the `url` crate to avoid constraining users to particular version of the crate.
