### PR TITLE
Disable hyper's default-features (OpenSSL)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ rust-crypto = "0.2"
 rustc-serialize = "0.3"
 time = "0.1"
 url = "1.2"
-hyper = { version = "0.9", optional = true }
+hyper = { version = "0.9", default-features = false, optional = true }


### PR DESCRIPTION
This change allows library users to opt-out OpenSSL. It's useful when building against platforms where it's infeasible to install OpenSSL.