### PR TITLE
1.0.6: Update to *ring* 0.9.4.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauthcli"
-version = "1.0.5"
+version = "1.0.6"
 authors = ["azyobuzin <azyobuzin@users.sourceforge.jp>"]
 description = "Implementation of OAuth 1.0 (and Twitter's f*ckin' OAuth) Client"
 documentation = "https://docs.rs/oauthcli/1.0.5/oauthcli/"
@@ -16,7 +16,7 @@ travis-ci = { repository = "azyobuzin/rust-oauthcli" }
 [dependencies]
 base64 = "0.5"
 rand = "0.3"
-ring = { version = "0.8", default-features = false }
+ring = { version = "0.9.4", default-features = false }
 time = "0.1"
 url = "1"
 hyper = { version = "0.9", default-features = false, optional = true }


### PR DESCRIPTION
Before *ring* 0.9.3, it was possible to link multiple versions of *ring* into a program, e.g. if one version depended on *ring* 0.6 and another dependend on *ring* 0.9. Unfortunately, this doesn't work, because the linker doesn't know to how to link *ring*'s C/asm code correctly in that kind of situation. *ring* 0.9.3 added a flag to its Cargo.toml to tell the Rust toolchain to stop allowing multiple versions of *ring* to be linked into the same program, to prevent any problems this may cause.

*ring* 0.9.4 was released with an update to make some crates easier to update to 0.9.x.

Note that is, in some ways, kind of a backward-compatible change. Let me know if you me to change the  rust-oauthcli version number to 2.0.0 to reflect this.